### PR TITLE
Some objects were renamed to avoid conflicts with build-in names

### DIFF
--- a/scripts/AVM_hubblesite_long_caption_links.py
+++ b/scripts/AVM_hubblesite_long_caption_links.py
@@ -110,13 +110,13 @@ def check_reachability(url):
 
 
 def get_long_caption_link(url, iterator, check_reachability_flag = True):
-    '''
+    """
     NOT VALID
     This was the first try to get long_caption_links
-    by simply using the last letter of .id 
+    by simply using the last letter of .id
     heic0515c --> hubblesite.org/...../image/c/
     Unfortunately this points very often to a different image
-    '''
+    """
     long_c = None
     try:
         remote   = urllib.request.urlopen(url)
@@ -152,38 +152,40 @@ def analyse(images):
     hubblesite: 800
     heritage: 55
     '''
-    dict = {}  #dict containing little dicts ldict
+    my_dict = {}  # dict containing little dicts ldict
     ldict = {}
-    list = []
-    linkdict = {} # collects the possible roots for long_caption_links
+    my_list = []
+    link_dict = {}  # collects the possible roots for long_caption_links
     for image in images:
-        if image.long_caption_link.find('http') == -1: continue
+        if image.long_caption_link.find('http') == -1:
+            continue
 
-        list.append(image.id)
+        my_list.append(image.id)
 
         prefix = image.id[:3]
-        link   = get_root(image.long_caption_link)
-        if link in linkdict:
-            linkdict[link] = linkdict[link] + 1
-        else: linkdict[link] = 1
-        if prefix in dict:
-            ldict = dict[prefix]
+        link = get_root(image.long_caption_link)
+        if link in link_dict:
+            link_dict[link] = link_dict[link] + 1
+        else:
+            link_dict[link] = 1
+        if prefix in my_dict:
+            ldict = my_dict[prefix]
             if link in ldict:
                 n = ldict[link]
                 n = n + 1
                 ldict[link] = n
             if link not in ldict:
                 ldict[link] = 1
-        dict[prefix] = ldict
-        if not prefix in dict:
+        my_dict[prefix] = ldict
+        if not prefix in my_dict:
             ldict = {}
             ldict[link] = 1
-            dict[prefix] = ldict
-    list.sort()
-    print(list)
-    for d in list(dict.keys()):
-        print(d, dict[d])
-    print(linkdict)
+            my_dict[prefix] = ldict
+    my_list.sort()
+    print(my_list)
+    for d in my_dict.keys():
+        print(d, my_dict[d])
+    print(link_dict)
 
 def get_related_PR(id):
     temp = ''   


### PR DESCRIPTION
By changing the variable name from list to my_list and dict to my_dict, you avoid conflicts with the built-in names in Python.