### PR TITLE
Old docker-compose mentions were replaces to docker compose v2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -158,6 +158,6 @@ devserver:
     - echo "$SSH_KNOWN_HOSTS" >> ~/.ssh/known_hosts
     - chmod 644 ~/.ssh/known_hosts
   script:
-    - ssh root@167.172.101.24 'cd esahubble && git pull origin release/python3 && docker-compose -f docker-compose.yml -f docker-compose.devserver.yml up --build -d'
+    - ssh root@167.172.101.24 'cd esahubble && git pull origin release/python3 && docker compose -f docker-compose.yml -f docker-compose.devserver.yml up --build -d'
   rules:
     - if: $CI_COMMIT_BRANCH == 'release/python3'

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,24 @@
 prod-up:
-	docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+	docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 
 prod-up-build:
-	docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
+	docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
 
 dev-up-build:
-	docker-compose -f docker-compose.yml -f docker-compose.devserver.yml up -d --build
+	docker compose -f docker-compose.yml -f docker-compose.devserver.yml up -d --build
 
 # Press Ctrl + Z to make it a background process, but "exit" finishes the process instead of logout
 prod-up-attached:
-	docker-compose -f docker-compose.yml -f docker-compose.prod.yml up
+	docker compose -f docker-compose.yml -f docker-compose.prod.yml up
 
 prod-up-build-attached:
-	docker-compose -f docker-compose.yml -f docker-compose.prod.yml up --build
+	docker compose -f docker-compose.yml -f docker-compose.prod.yml up --build
 
 prod-stop:
-	docker-compose -f docker-compose.yml -f docker-compose.prod.yml stop
+	docker compose -f docker-compose.yml -f docker-compose.prod.yml stop
 
 dev-stop:
-	docker-compose -f docker-compose.yml -f docker-compose.devserver.yml stop
+	docker compose -f docker-compose.yml -f docker-compose.devserver.yml stop
 
 reload-nginx:
 	docker exec -it webb-nginx service nginx reload

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ All the configuration to start the project is present in the docker-compose file
 then at this point a single command is required to download all the dependencies and run the project:
 
 ```` 
-docker-compose up
+docker compose up
 ````
 
 > The previous command reads the config from docker-compose.yml and docker-compose.override.yml, because of the naming convention of docker-compose
@@ -39,7 +39,7 @@ CTRL + C
 If the dependencies change, you should recreate the docker images and start the containers again with this command:
 
 ```` 
-docker-compose up --build
+docker compose up --build
 ````
 
 ### Additional commands
@@ -194,7 +194,7 @@ In case of new updates pull the commits from the repository and run the same com
 
 If the updates only changes the docker configuration just run:
 ```
-docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 ```
 or
 ```
@@ -203,7 +203,7 @@ make prod-up
 
 To start the containers displaying the startup logs:
 ```
-docker-compose -f docker-compose.yml -f docker-compose.prod.yml up
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up
 ```
 or
 ```

--- a/docker-compose.devserver.yml
+++ b/docker-compose.devserver.yml
@@ -1,6 +1,4 @@
-version: "3.4"
-
-# DEV CONFIG: 'docker-compose up' reads it automatically along with the docker-compose.yml file
+# DEV CONFIG: 'docker compose up' reads it automatically along with the docker-compose.yml file
 # See: https://docs.docker.com/compose/extends/
 
 x-common: &common

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,11 +1,9 @@
-version: "3.4"
-
-# DEV CONFIG: 'docker-compose up' reads it automatically along with the docker-compose.yml file
+# DEV CONFIG: 'docker compose up' reads it automatically along with the docker-compose.yml file
 # See: https://docs.docker.com/compose/extends/
 
 # Tip: Put djangoplicity source code with a symbolic link into the local folder, then add a volume like this one:
-# - ./local/djangoplicity/media/tasks.py:/home/hubbleadm/.local/lib/python3.8/site-packages/djangoplicity/media/tasks.py
-# To debug the code changes
+# - ./local/djangoplicity/media/tasks.py:/home/webbadm/.local/lib/python3.8/site-packages/djangoplicity/media/tasks.py
+# To debug the code changes, it only works with files, not directories
 x-common: &common
   build: .
   environment:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,6 +1,4 @@
-version: "3.4"
-
-# PRODUCTION CONFIG: use it like this 'docker-compose -f docker-compose.yml -f docker-compose.prod.yml up'
+# PRODUCTION CONFIG: use it like this 'docker compose -f docker-compose.yml -f docker-compose.prod.yml up'
 # See: https://docs.docker.com/compose/extends/
 
 x-common: &common

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 # BASE CONFIG: applies to all environments, does not work alone
 # See: https://docs.docker.com/compose/extends/
 


### PR DESCRIPTION
Effective July 2023, Compose V1 stopped receiving updates and is no longer in new Docker Desktop releases. Compose V2 has replaced it and is now integrated into all current Docker Desktop versions. For more information, see Migrate to Compose V2.