### PR TITLE
Added test-ssh file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,22 +17,3 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-
-name: Test SSH connection
-
-on:
-  push:
-    branches:
-      - develop
-
-jobs:
-  test-ssh:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Set up SSH
-      uses: webfactory/ssh-agent@v0.5.3
-      with:
-        ssh-private-key: ${{ secrets.SSH_KEY }}
-
-    - name: Test SSH connection
-      run: ssh -o StrictHostKeyChecking=no root@159.65.230.117 "echo 'SSH connection successful'"

--- a/.github/workflows/test-ssh.yml
+++ b/.github/workflows/test-ssh.yml
@@ -1,0 +1,18 @@
+name: Test SSH connection
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  test-ssh:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up SSH
+      uses: webfactory/ssh-agent@v0.5.3
+      with:
+        ssh-private-key: ${{ secrets.SSH_KEY }}
+
+    - name: Test SSH connection
+      run: ssh -o StrictHostKeyChecking=no root@159.65.230.117 "echo 'SSH connection successful'"


### PR DESCRIPTION
Create the test-ssh file to separate the workflows. Because having two name: blocks creates a conflict. This avoids this conflict and allows each workflow to have its own configuration file and to support it in a more organized way.